### PR TITLE
feat(export): add post_modified column next to post_date

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+Promoted, project-specific knowledge for agents working in this repo. Items
+here are reviewed and approved via `/reflect` (sourced from `REFLECTION.md`).
+Read this at the start of every session.
+
+## GOTCHAS
+
+- **CSV header source-of-truth:** When a CSV file gets its header from an
+  explicit `echo "..." > "$FILE"`, every subsequent `wp post list ... >>
+  "$FILE"` append MUST pipe through `tail -n +2` to drop WP-CLI's own header.
+  Local and remote branches must be symmetric on this. The Perl merge skips
+  only ONE header line, and the `awk 'NF == cols'` validation won't catch a
+  header-shaped junk row (it has a valid field count). _(PR #3, 2026-06-11)_
+
+## WORKFLOW
+
+- **Adding/removing an export column** ripples across ~6 coordinated sites in
+  `export_wp_posts.sh`. Audit all of them: both the local AND remote WP-CLI
+  `--fields=` lists, the CSV header `echo`, `EXPECTED_COLUMNS` (static default
+  + dynamic `$((... ))`), the Perl field-count guard + field indices, the
+  `MERGE_HEADER`, and the Excel column offsets (`DATE_COL`/`STATUS_COL`/etc.).
+  _(PR #3, 2026-06-11)_
+
+- **Multi-branch shell pipelines (local vs remote):** Diff the branches
+  against each other first. Asymmetries between paths that "should" behave
+  identically are where latent bugs hide. _(PR #3, 2026-06-11)_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ The `export_wp_posts.sh` script follows this execution flow:
 - RemoteCommand detection uses `ssh -G <host>` to resolve effective SSH config
 - Empty bash arrays use `${array[@]+"${array[@]}"}` pattern for `set -u` compatibility
 - Creates outputs in timestamped directories with domain names (e.g., `!export_wp_posts_20250811_143244_example-com/`)
-- Dynamic `EXPECTED_COLUMNS` computed as 7 base + number of custom meta fields
+- Dynamic `EXPECTED_COLUMNS` computed as 8 base + number of custom meta fields
 - Uses HYPERLINK formula in Excel for clickable URLs while maintaining clean CSV format
 - Dynamically discovers post types rather than hardcoding them
 - Domain history saved immediately after selection (not end of script) to survive early exits
@@ -169,7 +169,7 @@ This parser correctly handles:
 - Escaped quotes within quoted fields
 - Mixed quoted and unquoted fields
 
-The Perl merge script accepts N additional meta field files via `ARGV[2+]`, loading each into `%meta_data{field_name}{post_id}`. Output column order: `ID, post_title, post_name, custom_permalink, [meta fields...], post_date, post_status, post_type`.
+The Perl merge script accepts N additional meta field files via `ARGV[2+]`, loading each into `%meta_data{field_name}{post_id}`. Output column order: `ID, post_title, post_name, custom_permalink, [meta fields...], post_date, post_modified, post_status, post_type`.
 
 ### Excel Generation
 Python heredoc builds headers dynamically based on `custom_meta_keys` list. Column positions for date, status, type, and edit link adjust automatically based on meta field count.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The generated Excel file includes:
 - **Custom Meta Columns**: Inserted between custom_permalink and post_date (if any meta fields were exported)
 - **Last Column**: Clickable WP Admin edit links
 
-The number of columns adjusts dynamically based on how many custom meta fields are exported. The base is 7 columns (ID, title, name, custom_permalink, date, status, type) plus one column per meta field, plus the URL formula and edit link columns.
+The number of columns adjusts dynamically based on how many custom meta fields are exported. The base is 8 columns (ID, title, name, custom_permalink, date, modified, status, type) plus one column per meta field, plus the URL formula and edit link columns.
 
 ## Requirements
 
@@ -152,15 +152,16 @@ The script stores configuration in `.config/wp-export-config.json` (gitignored) 
 
 ## Exported Data
 
-### Posts Export (7+ columns)
+### Posts Export (8+ columns)
 1. **ID**: Post ID
 2. **post_title**: Title (sanitized, commas removed)
 3. **post_name**: URL slug
 4. **custom_permalink**: Custom permalink if set
 5. *[Custom meta fields]*: Any additional meta keys requested during export
 6. **post_date**: Publication date
-7. **post_status**: Status (publish, draft, etc.)
-8. **post_type**: Type (post, page, custom types)
+7. **post_modified**: Last modified date
+8. **post_status**: Status (publish, draft, etc.)
+9. **post_type**: Type (post, page, custom types)
 
 ### Custom Meta Fields
 

--- a/REFLECTION.md
+++ b/REFLECTION.md
@@ -5,7 +5,7 @@ to project standards (e.g. AGENTS.md / CLAUDE.md). Newest entries on top.
 
 ---
 
-## 2026-06-11 — PR #3: add `post_modified` column
+## 2026-06-11 — PR #3: add `post_modified` column [REVIEWED 2026-06-11 - APPROVED]
 
 **Task:** Add `post_modified` as a permanent export column immediately after
 `post_date`, threaded through WP-CLI fields, the Perl merge, and Excel output.

--- a/REFLECTION.md
+++ b/REFLECTION.md
@@ -1,0 +1,34 @@
+# REFLECTION
+
+Agent learning log. Entries here feed `/reflect`; approved items get promoted
+to project standards (e.g. AGENTS.md / CLAUDE.md). Newest entries on top.
+
+---
+
+## 2026-06-11 — PR #3: add `post_modified` column
+
+**Task:** Add `post_modified` as a permanent export column immediately after
+`post_date`, threaded through WP-CLI fields, the Perl merge, and Excel output.
+
+**Surprised by:** Reviewing the touched code surfaced a *pre-existing* bug in
+the local export path — the posts CSV header was echoed once **and** the first
+post type's WP-CLI output was appended with its own header (no `tail -n +2`),
+so a duplicate header leaked through the Perl merge as a junk data row. It was
+non-obvious because (a) remote mode was unaffected (it always strips the
+header), and (b) the `awk 'NF == cols'` validation *passes* the junk row since
+it has a valid field count, so nothing downstream flags it.
+
+**Proposed AGENTS.md / CLAUDE.md additions:**
+- GOTCHA: When a CSV file gets its header from an explicit `echo "..." >
+  "$FILE"`, every subsequent `wp post list ... >> "$FILE"` append MUST pipe
+  through `tail -n +2` to drop WP-CLI's own header. Local and remote branches
+  must be symmetric on this. The merge only skips ONE header line, and the
+  `NF == cols` guard won't catch a header-shaped junk row.
+- WORKFLOW: When adding a column, audit BOTH the local and remote export
+  branches plus the `EXPECTED_COLUMNS` math, the Perl field-count guard, the
+  merge header, and the Excel column offsets — column changes ripple across
+  ~6 coordinated sites in this script.
+
+**Prompt improvement:** When a task touches a multi-branch shell pipeline
+(local vs remote), diff the branches against each other first — asymmetries
+between paths that "should" behave identically are where latent bugs hide.

--- a/export_wp_posts.sh
+++ b/export_wp_posts.sh
@@ -6,7 +6,7 @@
 #   Unified WordPress export script that can run either locally or via SSH.
 #   Exports WordPress posts and custom permalink information using WP-CLI,
 #   then merges the data into a final CSV with columns in the order:
-#   ID, post_title, post_name, custom_permalink, post_date, post_status, post_type.
+#   ID, post_title, post_name, custom_permalink, post_date, post_modified, post_status, post_type.
 #
 #   Additionally exports WordPress users with their details and post counts 
 #   across all public post types (excluding attachments).
@@ -124,9 +124,9 @@ if [ "$EXCEL_AVAILABLE" -eq 0 ]; then
 fi
 
 # Expected final columns for merged posts (computed dynamically after meta field prompt):
-# Base: ID, post_title, post_name, custom_permalink, post_date, post_status, post_type = 7
+# Base: ID, post_title, post_name, custom_permalink, post_date, post_modified, post_status, post_type = 8
 # Plus any custom meta fields the user adds
-EXPECTED_COLUMNS=7
+EXPECTED_COLUMNS=8
 
 # Flag: set to 1 when permalink structure requires full path export
 EXPORT_PERMALINK_PATH=0
@@ -977,15 +977,15 @@ if [ ${#CUSTOM_META_KEYS[@]} -gt 0 ]; then
     echo -e "${GREEN}Will export meta fields: ${CUSTOM_META_KEYS[*]}${NC}"
 fi
 
-# Dynamic column count: 7 base columns + number of custom meta fields
-EXPECTED_COLUMNS=$((7 + EXPORT_PERMALINK_PATH + ${#CUSTOM_META_KEYS[@]}))
+# Dynamic column count: 8 base columns + number of custom meta fields
+EXPECTED_COLUMNS=$((8 + EXPORT_PERMALINK_PATH + ${#CUSTOM_META_KEYS[@]}))
 
 #########################################
 # Export Posts and Custom Permalink Data
 #########################################
 
 # Export posts with all required fields
-echo "ID,post_title,post_name,post_date,post_status,post_type" > "$ALL_POSTS_FILE"
+echo "ID,post_title,post_name,post_date,post_modified,post_status,post_type" > "$ALL_POSTS_FILE"
 
 echo -e "\n${YELLOW}Exporting all posts...${NC}"
 if [ "$REMOTE_MODE" -eq 1 ]; then
@@ -1001,13 +1001,13 @@ for post_type in "${POST_TYPES[@]}"; do
         if [ "$FIRST" -eq 1 ]; then
             # First type - include headers
             wp post list --post_type="$post_type" --post_status=any \
-                --fields=ID,post_title,post_name,post_date,post_status,post_type \
+                --fields=ID,post_title,post_name,post_date,post_modified,post_status,post_type \
                 --format=csv --allow-root >> "$ALL_POSTS_FILE"
             FIRST=0
         else
             # Subsequent types - skip headers
             wp post list --post_type="$post_type" --post_status=any \
-                --fields=ID,post_title,post_name,post_date,post_status,post_type \
+                --fields=ID,post_title,post_name,post_date,post_modified,post_status,post_type \
                 --format=csv --allow-root | tail -n +2 >> "$ALL_POSTS_FILE"
         fi
         
@@ -1020,7 +1020,7 @@ for post_type in "${POST_TYPES[@]}"; do
         fi
     else
         # Remote export
-        REMOTE_CMD=$(build_remote_cmd "cd \"$WP_PATH\" && wp post list --post_type=$post_type --post_status=any --fields=ID,post_title,post_name,post_date,post_status,post_type --format=csv 2>/dev/null")
+        REMOTE_CMD=$(build_remote_cmd "cd \"$WP_PATH\" && wp post list --post_type=$post_type --post_status=any --fields=ID,post_title,post_name,post_date,post_modified,post_status,post_type --format=csv 2>/dev/null")
         [ "$VERBOSE" -eq 1 ] && echo -e "    ${YELLOW}[SSH] $REMOTE_CMD${NC}"
         EXPORT_OUTPUT=$(ssh $SSH_OPTS "$SSH_CONNECTION" "$REMOTE_CMD" 2>"$SSH_STDERR" || echo "FAILED")
         
@@ -1136,7 +1136,7 @@ fi
 
 echo -e "\n${YELLOW}Merging posts data using improved CSV parser...${NC}"
 
-# Build dynamic header: ID,post_title,post_name,custom_permalink,[permalink_path],[meta fields],post_date,post_status,post_type
+# Build dynamic header: ID,post_title,post_name,custom_permalink,[permalink_path],[meta fields],post_date,post_modified,post_status,post_type
 MERGE_HEADER="ID,post_title,post_name,custom_permalink"
 if [ "$EXPORT_PERMALINK_PATH" -eq 1 ]; then
     MERGE_HEADER="$MERGE_HEADER,permalink_path"
@@ -1144,7 +1144,7 @@ fi
 for meta_key in ${CUSTOM_META_KEYS[@]+"${CUSTOM_META_KEYS[@]}"}; do
     MERGE_HEADER="$MERGE_HEADER,$meta_key"
 done
-MERGE_HEADER="$MERGE_HEADER,post_date,post_status,post_type"
+MERGE_HEADER="$MERGE_HEADER,post_date,post_modified,post_status,post_type"
 echo "$MERGE_HEADER" > "$TEMP_FILE"
 
 # Use perl for reliable CSV parsing (perl is always available on macOS)
@@ -1254,13 +1254,14 @@ while (my $line = <$posts_fh>) {
     chomp $line;
     my @fields = parse_csv_line($line);
 
-    if (@fields >= 6) {
+    if (@fields >= 7) {
         my $id = $fields[0];
         my $title = $fields[1];
         my $post_name = $fields[2];
         my $post_date = $fields[3];
-        my $post_status = $fields[4];
-        my $post_type = $fields[5];
+        my $post_modified = $fields[4];
+        my $post_status = $fields[5];
+        my $post_type = $fields[6];
 
         # Remove commas from title
         $title =~ s/,//g;
@@ -1275,11 +1276,11 @@ while (my $line = <$posts_fh>) {
         my @extras = map { $meta_data{$_}{$id} || "" } @meta_names;
         my $extras_str = join(",", @extras);
 
-        # Output: ID,title,name,custom_permalink,[permalink_path],[extras],date,status,type
+        # Output: ID,title,name,custom_permalink,[permalink_path],[extras],date,modified,status,type
         my @out = ($id, $title, $post_name, $custom);
         push @out, $ppath if $export_permalink_path;
         push @out, @extras if @extras;
-        push @out, ($post_date, $post_status, $post_type);
+        push @out, ($post_date, $post_modified, $post_status, $post_type);
         print join(",", @out) . "\n";
 
         print STDERR "Processed row: $id\n" if $ENV{DEBUG};
@@ -1429,20 +1430,21 @@ custom_meta_keys = ${PYTHON_META_LIST}
 export_permalink_path = bool(${EXPORT_PERMALINK_PATH})
 
 # Build dynamic headers
-# Fixed: url, ID, post_title, post_name, custom_permalink, [permalink_path], [meta fields], post_date, post_status, post_type, edit WP Admin
+# Fixed: url, ID, post_title, post_name, custom_permalink, [permalink_path], [meta fields], post_date, post_modified, post_status, post_type, edit WP Admin
 headers = ["url", "ID", "post_title", "post_name", "custom_permalink"]
 if export_permalink_path:
     headers.append("permalink_path")
 headers.extend(custom_meta_keys)
-headers.extend(["post_date", "post_status", "post_type", "edit WP Admin"])
+headers.extend(["post_date", "post_modified", "post_status", "post_type", "edit WP Admin"])
 
 # Column positions (1-indexed for openpyxl)
 # A=url(1), B=ID(2), C=title(3), D=post_name(4), E=custom_permalink(5)
-# F=permalink_path(6) when present, then meta fields, then post_date, post_status, post_type, edit link
+# F=permalink_path(6) when present, then meta fields, then post_date, post_modified, post_status, post_type, edit link
 PERMALINK_PATH_COL = 6 if export_permalink_path else None
 META_START_COL = 6 + (1 if export_permalink_path else 0)
 DATE_COL = META_START_COL + len(custom_meta_keys)
-STATUS_COL = DATE_COL + 1
+MODIFIED_COL = DATE_COL + 1
+STATUS_COL = MODIFIED_COL + 1
 TYPE_COL = STATUS_COL + 1
 EDIT_COL = TYPE_COL + 1
 TOTAL_COLS = EDIT_COL
@@ -1515,6 +1517,7 @@ with open("$FINAL_CSV_FILE", 'r', encoding='utf-8') as f:
             ws.cell(row=row_num, column=META_START_COL + i).value = row.get(meta_key, '')
         # Remaining fixed columns
         ws.cell(row=row_num, column=DATE_COL).value = row.get('post_date', '')
+        ws.cell(row=row_num, column=MODIFIED_COL).value = row.get('post_modified', '')
         ws.cell(row=row_num, column=STATUS_COL).value = row.get('post_status', '')
         ws.cell(row=row_num, column=TYPE_COL).value = row.get('post_type', '')
         # Edit link formula

--- a/export_wp_posts.sh
+++ b/export_wp_posts.sh
@@ -992,25 +992,16 @@ if [ "$REMOTE_MODE" -eq 1 ]; then
     echo "Note: Remote hosts may close connections during large exports. This is normal."
 fi
 
-FIRST=1
 for post_type in "${POST_TYPES[@]}"; do
     echo "  Exporting post type: $post_type"
     
     if [ "$REMOTE_MODE" -eq 0 ]; then
-        # Local export
-        if [ "$FIRST" -eq 1 ]; then
-            # First type - include headers
-            wp post list --post_type="$post_type" --post_status=any \
-                --fields=ID,post_title,post_name,post_date,post_modified,post_status,post_type \
-                --format=csv --allow-root >> "$ALL_POSTS_FILE"
-            FIRST=0
-        else
-            # Subsequent types - skip headers
-            wp post list --post_type="$post_type" --post_status=any \
-                --fields=ID,post_title,post_name,post_date,post_modified,post_status,post_type \
-                --format=csv --allow-root | tail -n +2 >> "$ALL_POSTS_FILE"
-        fi
-        
+        # Local export — header already written above, so strip WP-CLI's header
+        # from every post type to avoid a duplicate header leaking in as a data row
+        wp post list --post_type="$post_type" --post_status=any \
+            --fields=ID,post_title,post_name,post_date,post_modified,post_status,post_type \
+            --format=csv --allow-root | tail -n +2 >> "$ALL_POSTS_FILE"
+
         if [ $? -eq 0 ]; then
             POST_COUNT=$(wp post list --post_type="$post_type" --post_status=any --format=count --allow-root)
             echo "    ✓ Exported $POST_COUNT $post_type(s)"


### PR DESCRIPTION
## What

Adds `post_modified` as a permanent column in the export, positioned immediately after `post_date`.

Final column order:
`ID, post_title, post_name, custom_permalink, [meta fields…], post_date, post_modified, post_status, post_type`

## Why

Surfaces each post's last-modified date alongside its publish date — useful for SEO audits and content-freshness analysis (identifying stale content, recently-updated pages, etc.).

## Changes

Coordinated across the full pipeline in `export_wp_posts.sh`:

- **WP-CLI export** — added `post_modified` to all three `--fields=` lists (local first/subsequent + remote) and the CSV header echo
- **Column count** — `EXPECTED_COLUMNS` base bumped `7 → 8` (static default + dynamic `$((8 + ...))`)
- **Perl merge** — read `post_modified` (`fields[4]`), shifted status/type to indices 5/6, raised the field guard to `>= 7`, emit it in the output row
- **Merge header** — `MERGE_HEADER` now includes `post_modified`
- **Excel generation** — added to headers + new `MODIFIED_COL` in column math (status/type/edit shift right automatically) + cell write

Docs updated: `CLAUDE.md` and `README.md` (column order + 8-base notes).

## Testing

- ✅ `bash -n export_wp_posts.sh` — syntax clean
- ✅ Python column-math snippet maps every header to the correct index
- ✅ Synthetic Perl merge produced correctly-ordered 8-column rows that pass the `awk NF==8` validation (incl. comma-in-title sanitizing)

## SEO impact

No URL/route/meta changes. Adds a data column to the export only — no impact on the live site or crawlable surface.---

## Review follow-up (duplicate-header fix)

Code review noticed a pre-existing bug in the code this PR touches: in **local** mode the posts CSV header was echoed once *and* the first post type's WP-CLI export was appended **with its own header** (no `tail -n +2`), so a second header row leaked through the Perl merge as a junk data row. (Remote mode was unaffected — it always strips the header.)

- Collapsed the local `FIRST`/else branches into a single export that strips WP-CLI's header for every post type, matching remote mode and the permalink/meta/user exports.
- Removed the now-unused `FIRST` flag.
- Net `-15/+6`; `bash -n` clean, no new ShellCheck warnings.---

### Pre-merge checklist
- [x] **Agent Reflection** — `/reflect` run; CSV-header GOTCHA + column-audit/multi-branch WORKFLOW rules promoted to `AGENTS.md` (commit on branch).